### PR TITLE
fix: flaky test

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -135,7 +135,7 @@ class URL implements Serializable {
 
     protected URL() {
         this.urlAddress = null;
-        this.urlParam = URLParam.parse(new HashMap<>());
+        this.urlParam = URLParam.parse(new LinkedHashMap<>());
         this.attributes = null;
     }
 
@@ -145,7 +145,7 @@ class URL implements Serializable {
 
     public URL(URLAddress urlAddress, URLParam urlParam, Map<String, Object> attributes) {
         this.urlAddress = urlAddress;
-        this.urlParam = null == urlParam ? URLParam.parse(new HashMap<>()) : urlParam;
+        this.urlParam = null == urlParam ? URLParam.parse(new LinkedHashMap<>()) : urlParam;
         this.attributes = (attributes != null ? attributes.isEmpty() ? null : attributes : null);
     }
 
@@ -261,7 +261,7 @@ class URL implements Serializable {
         if (reserveParams == null || reserveParams.length == 0) {
             return result;
         }
-        Map<String, String> newMap = new HashMap<>(reserveParams.length);
+        Map<String, String> newMap = new LinkedHashMap<>(reserveParams.length);
         Map<String, String> oldMap = result.getParameters();
         for (String reserveParam : reserveParams) {
             String tmp = oldMap.get(reserveParam);
@@ -273,7 +273,7 @@ class URL implements Serializable {
     }
 
     public static URL valueOf(URL url, String[] reserveParams, String[] reserveParamPrefixes) {
-        Map<String, String> newMap = new HashMap<>();
+        Map<String, String> newMap = new LinkedHashMap<>();
         Map<String, String> oldMap = url.getParameters();
         if (reserveParamPrefixes != null && reserveParamPrefixes.length != 0) {
             for (Map.Entry<String, String> entry : oldMap.entrySet()) {
@@ -928,7 +928,7 @@ class URL implements Serializable {
     }
 
     private void updateCachedNumber(String method, String key, Number n) {
-        Map<String, Number> keyNumber = getMethodNumbers().computeIfAbsent(method, m -> new HashMap<>());
+        Map<String, Number> keyNumber = getMethodNumbers().computeIfAbsent(method, m -> new LinkedHashMap<>());
         keyNumber.put(key, n);
     }
 
@@ -1122,7 +1122,7 @@ class URL implements Serializable {
         if (pairs.length % 2 != 0) {
             throw new IllegalArgumentException("Map pairs can not be odd number.");
         }
-        Map<String, String> map = new HashMap<>();
+        Map<String, String> map = new LinkedHashMap<>();
         int len = pairs.length / 2;
         for (int i = 0; i < len; i++) {
             map.put(pairs[2 * i], pairs[2 * i + 1]);
@@ -1184,7 +1184,7 @@ class URL implements Serializable {
     }
 
     public Map<String, String> toMap() {
-        Map<String, String> map = new HashMap<>(getParameters());
+        Map<String, String> map = new LinkedHashMap<>(getParameters());
         if (getProtocol() != null) {
             map.put(PROTOCOL_KEY, getProtocol());
         }
@@ -1554,7 +1554,7 @@ class URL implements Serializable {
     }
 
     public static void putMethodParameter(String method, String key, String value, Map<String, Map<String, String>> methodParameters) {
-        Map<String, String> subParameter = methodParameters.computeIfAbsent(method, k -> new HashMap<>());
+        Map<String, String> subParameter = methodParameters.computeIfAbsent(method, k -> new LinkedHashMap<>());
         subParameter.put(key, value);
     }
 
@@ -1648,7 +1648,7 @@ class URL implements Serializable {
 
     public URL putAttribute(String key, Object obj) {
         if (attributes == null) {
-            this.attributes = new HashMap<>();
+            this.attributes = new LinkedHashMap<>();
         }
         attributes.put(key, obj);
         return this;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.url.component.URLItemCache;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY_PREFIX;
@@ -67,7 +68,7 @@ public final class URLStrParser {
         }
 
         TempBuf tempBuf = DECODE_TEMP_BUF.get();
-        Map<String, String> params = new HashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
         int nameStart = from;
         int valueStart = -1;
         int i;
@@ -229,7 +230,7 @@ public final class URLStrParser {
         }
 
         TempBuf tempBuf = DECODE_TEMP_BUF.get();
-        Map<String, String> params = new HashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
         int nameStart = from;
         int valueStart = -1;
         int i;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -127,7 +127,7 @@ public class URLParam {
                 throw new IllegalArgumentException();
             }
         }
-        this.EXTRA_PARAMS = Collections.unmodifiableMap((extraParams == null ? new HashMap<>() : new HashMap<>(extraParams)));
+        this.EXTRA_PARAMS = Collections.unmodifiableMap((extraParams == null ? new LinkedHashMap<>() : new LinkedHashMap<>(extraParams)));
         this.METHOD_PARAMETERS = Collections.unmodifiableMap((methodParameters == null) ? Collections.emptyMap() : new LinkedHashMap<>(methodParameters));
         this.rawParam = rawParam;
 
@@ -138,7 +138,7 @@ public class URLParam {
     protected URLParam(BitSet key, int[] value, Map<String, String> extraParams, Map<String, Map<String, String>> methodParameters, String rawParam) {
         this.KEY = key;
         this.VALUE = value;
-        this.EXTRA_PARAMS = Collections.unmodifiableMap((extraParams == null ? new HashMap<>() : new HashMap<>(extraParams)));
+        this.EXTRA_PARAMS = Collections.unmodifiableMap((extraParams == null ? new LinkedHashMap<>() : new LinkedHashMap<>(extraParams)));
         this.METHOD_PARAMETERS = Collections.unmodifiableMap((methodParameters == null) ? Collections.emptyMap() : new LinkedHashMap<>(methodParameters));
         this.rawParam = rawParam;
         this.timestamp = System.currentTimeMillis();
@@ -209,7 +209,7 @@ public class URLParam {
     }
 
     public static Map<String, Map<String, String>> initMethodParameters(Map<String, String> parameters) {
-        Map<String, Map<String, String>> methodParameters = new HashMap<>();
+        Map<String, Map<String, String>> methodParameters = new LinkedHashMap<>();
         if (parameters == null) {
             return methodParameters;
         }
@@ -555,15 +555,15 @@ public class URLParam {
             if (keyIndex < 0) {
                 // entry key is not present in DynamicParamTable, add it to EXTRA_PARAMS
                 if (newExtraParams == null) {
-                    newExtraParams = new HashMap<>(EXTRA_PARAMS);
+                    newExtraParams = new LinkedHashMap<>(EXTRA_PARAMS);
                 }
                 newExtraParams.put(entry.getKey(), entry.getValue());
                 String[] methodSplit = entry.getKey().split("\\.");
                 if (methodSplit.length == 2) {
                     if (newMethodParams == null) {
-                        newMethodParams = new HashMap<>(METHOD_PARAMETERS);
+                        newMethodParams = new LinkedHashMap<>(METHOD_PARAMETERS);
                     }
-                    Map<String, String> methodMap = newMethodParams.computeIfAbsent(methodSplit[1], (k) -> new HashMap<>());
+                    Map<String, String> methodMap = newMethodParams.computeIfAbsent(methodSplit[1], (k) -> new LinkedHashMap<>());
                     methodMap.put(methodSplit[0], entry.getValue());
                 }
             } else {
@@ -618,7 +618,7 @@ public class URLParam {
     }
 
     private Map<Integer, Integer> recoverValue() {
-        Map<Integer, Integer> map = new HashMap<>((int) (KEY.size() / 0.75) + 1);
+        Map<Integer, Integer> map = new LinkedHashMap<>((int) (KEY.size() / 0.75) + 1);
         for (int i = KEY.nextSetBit(0), offset = 0; i >= 0; i = KEY.nextSetBit(i + 1)) {
             map.put(i, VALUE[offset++]);
         }
@@ -684,14 +684,14 @@ public class URLParam {
             }
             if (EXTRA_PARAMS.containsKey(key)) {
                 if (newExtraParams == null) {
-                    newExtraParams = new HashMap<>(EXTRA_PARAMS);
+                    newExtraParams = new LinkedHashMap<>(EXTRA_PARAMS);
                 }
                 newExtraParams.remove(key);
 
                 String[] methodSplit = key.split("\\.");
                 if (methodSplit.length == 2) {
                     if (newMethodParams == null) {
-                        newMethodParams = new HashMap<>(METHOD_PARAMETERS);
+                        newMethodParams = new LinkedHashMap<>(METHOD_PARAMETERS);
                     }
                     Map<String, String> methodMap = newMethodParams.get(methodSplit[1]);
                     if (CollectionUtils.isNotEmptyMap(methodMap)) {
@@ -948,9 +948,9 @@ public class URLParam {
 
         int capacity = (int) (parts.length / .75f) + 1;
         BitSet keyBit = new BitSet(capacity);
-        Map<Integer, Integer> valueMap = new HashMap<>(capacity);
-        Map<String, String> extraParam = new HashMap<>(capacity);
-        Map<String, Map<String, String>> methodParameters = new HashMap<>(capacity);
+        Map<Integer, Integer> valueMap = new LinkedHashMap<>(capacity);
+        Map<String, String> extraParam = new LinkedHashMap<>(capacity);
+        Map<String, Map<String, String>> methodParameters = new LinkedHashMap<>(capacity);
 
         for (String part : parts) {
             part = part.trim();
@@ -989,9 +989,9 @@ public class URLParam {
         if (CollectionUtils.isNotEmptyMap(params)) {
             int capacity = (int) (params.size() / .75f) + 1;
             BitSet keyBit = new BitSet(capacity);
-            Map<Integer, Integer> valueMap = new HashMap<>(capacity);
-            Map<String, String> extraParam = new HashMap<>(capacity);
-            Map<String, Map<String, String>> methodParameters = new HashMap<>(capacity);
+            Map<Integer, Integer> valueMap = new LinkedHashMap<>(capacity);
+            Map<String, String> extraParam = new LinkedHashMap<>(capacity);
+            Map<String, Map<String, String>> methodParameters = new LinkedHashMap<>(capacity);
 
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 addParameter(keyBit, valueMap, extraParam, methodParameters, entry.getKey(), entry.getValue(), false);
@@ -1021,7 +1021,7 @@ public class URLParam {
             extraParam.put(key, value);
             String[] methodSplit = key.split("\\.", 2);
             if (methodSplit.length == 2) {
-                Map<String, String> methodMap = methodParameters.computeIfAbsent(methodSplit[1], (k) -> new HashMap<>());
+                Map<String, String> methodMap = methodParameters.computeIfAbsent(methodSplit[1], (k) -> new LinkedHashMap<>());
                 methodMap.put(methodSplit[0], value);
             }
         } else {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
@@ -1023,6 +1023,7 @@ public class URLTest {
         URL url2 = URL.valueOf("consumer://30.225.20.150/org.apache.dubbo.rpc.service.GenericService?application=" +
             "dubbo-demo-api-consumer&category=consumers&check=false&dubbo=2.0.2&generic=true&interface=" +
             "org.apache.dubbo.demo.DemoService&pid=7375&side=consumer&sticky=false&timestamp=2299556506417");
+        // Fixing this flaky test
         assertEquals(url1.hashCode(), url2.hashCode());
 
         URL url3 = URL.valueOf("consumer://30.225.20.150/org.apache.dubbo.rpc.service.GenericService?application=" +


### PR DESCRIPTION
Fixing Flaky Test - 
Coverting HashMap to LinkedHashMap since it was causing the order of the params of the URL in the test to change and causing the JUNIT test case to fail
